### PR TITLE
VF-607 feature Allows to extend models

### DIFF
--- a/lib/model/definition.js
+++ b/lib/model/definition.js
@@ -1,4 +1,4 @@
-const {values, snakeCase, uniq} = require('lodash');
+const {values, snakeCase, uniq, isString, isFunction} = require('lodash');
 const snakeobj = require('snakeobj');
 const buildCrud = require('./crud');
 const {BadInputError} = require('./../errors');
@@ -16,43 +16,72 @@ const types = {
 
 const validTypes = values(types);
 
+const modelFunctions = [
+  'getKnownFields', 'getFieldType', 'validatesUniquenessOf',
+  'getUniqueIndexes', 'extend'
+];
+
 const defineModel = (args = {}) => {
   _validateDefinition(args.definition);
 
   const {collection, engine} = args;
   const definition = snakeobj(args.definition);
   const uniqueIndexes = [];
+  let extendedModel;
 
   const getKnownFields = (data, schema) => {
-    return Object.keys(snakeobj(data)).filter(determineKnownField);
-  };
-
-  const determineKnownField = field => {
-    const knownFields = Object.keys(definition);
-    return knownFields.includes(field);
+    return Object.keys(snakeobj(data)).filter(isKnownField);
   };
 
   const getFieldType = (field) => definition[field];
 
   const validatesUniquenessOf = (...fields) => {
-    const known = uniq(fields.map(snakeCase).filter(determineKnownField));
+    const known = uniq(fields.map(snakeCase).filter(isKnownField));
     known.forEach(appendFieldToUnique);
     return known;
   };
+
+  const extend = (model, fk) => {
+    const foreignKey = snakeCase(fk);
+    if (isUnknownField(foreignKey) || isNotModel(model)) return;
+    setExtendedModel(model, foreignKey);
+    return Object.assign({}, extendedModel);
+  };
+
+  const setExtendedModel = (model, foreignKey) => {
+    extendedModel = {name: model.collection, model, foreignKey};
+  };
+
+  const isKnownField = field => {
+    const knownFields = Object.keys(definition);
+    return knownFields.includes(field);
+  };
+
+  const isUnknownField = field => !isKnownField(field);
 
   const appendFieldToUnique = field => {
     if (!uniqueIndexes.includes(field)) uniqueIndexes.push(field);
   };
 
-  const getUniqueIndexes = () => [].concat(uniqueIndexes);
+  const getUniqueIndexes = () => [...uniqueIndexes];
 
   const schema = {
     collection, getKnownFields, getFieldType,
-    validatesUniquenessOf, getUniqueIndexes
+    validatesUniquenessOf, getUniqueIndexes, extend
   };
+
   const crud = buildCrud(engine, schema);
 
   return Object.assign({}, schema, crud);
+};
+
+const isNotModel = model => !isModel(model);
+
+const isModel = model => {
+  if (!isString(model.collection)) return false;
+  return modelFunctions.reduce((valid, func) => {
+    return valid && isFunction(model[func]);
+  }, true);
 };
 
 const _validateDefinition = definition => {

--- a/test/run/model/definition.spec.js
+++ b/test/run/model/definition.spec.js
@@ -158,4 +158,60 @@ describe('Model', () => {
       expect(model.getUniqueIndexes()).to.include('age');
     });
   });
+
+  describe('extend', () => {
+    const PostModel = defineModel({
+      collection: 'posts',
+      engine,
+      definition: {
+        id: types.INTEGER,
+        externalId: types.STRING
+      }
+    });
+
+    it('accepts returns extended model object', () => {
+      const DetailedPostModel = defineModel({
+        collection: 'detailed_posts',
+        engine,
+        definition: {
+          content: types.TEXT,
+          postId: types.INTEGER
+        }
+      });
+
+      const result = DetailedPostModel.extend(PostModel, 'postId');
+      expect(result).to.exist;
+      expect(result.foreignKey).to.be.equal('post_id');
+      expect(result.name).to.be.equal('posts');
+      expect(result.model).to.be.deep.equal(PostModel);
+    });
+
+    it('returs undefined if foreign key is not a valid field', () => {
+      const DetailedPostModel = defineModel({
+        collection: 'detailed_posts',
+        engine,
+        definition: {
+          content: types.TEXT
+        }
+      });
+      const result = DetailedPostModel.extend(PostModel, 'postId');
+      expect(result).not.to.exist;
+    });
+
+    it('returns undefined if model does not look like model', () => {
+      const NotAModel = {
+        notAModel: 'nope'
+      };
+      const DetailedPostModel = defineModel({
+        collection: 'detailed_posts',
+        engine,
+        definition: {
+          content: types.TEXT,
+          postId: types.STRING
+        }
+      });
+      const result = DetailedPostModel.extend(NotAModel, 'postId');
+      expect(result).not.to.exist;
+    });
+  });
 });


### PR DESCRIPTION
Enables model extension useful to create a model that has data from two tables.

```js
const PostModel = defineModel({
  collection: 'posts',
  engine,
  definition: {
    id: types.INTEGER,
    externalId: types.STRING
  }
});

const DetailedPostModel = defineModel({
  collection: 'detailed_posts',
  engine,
  definition: {
    content: types.TEXT,
    postId: types.INTEGER
  }
});
const extensionData = DetailedPostModel.extend(PostModel, 'postId');
```

Extension data looks like:
```js
{name: 'posts', model: {//A full model!!}, foreignKey: 'post_id'}
```