### PR TITLE
Ads support to remove extended tables in postgres

### DIFF
--- a/lib/drivers/postgres/transpiler.js
+++ b/lib/drivers/postgres/transpiler.js
@@ -41,8 +41,34 @@ const PostgresTranspiler = model => {
   };
 
   const remove = query => {
+    if (model.isExtended()) return _extendedRemove(snakeobj(query));
+    return _remove(snakeobj(query));
+  };
+
+  const _extendedRemove = query => {
+    const {where} = query;
+    if (!where) return _extendedRemoveAll();
+    const {foreignKey} = model.getExtendedModel();
+    const primaryKey = model.getExtendedModel().model.getPrimaryKey();
+    const parentTable = model.getExtendedModel().name;
+    const subselect = `WITH ids as (${select(query)}) `;
+
+    return 'BEGIN; ' + subselect +
+    `DELETE FROM ${tableName} WHERE ${tableName}.${foreignKey} IN ` +
+    `(SELECT ${primaryKey} FROM ids);` + subselect +
+    `DELETE FROM ${parentTable} WHERE ${parentTable}.${primaryKey} IN ` +
+    `(SELECT ${primaryKey} FROM ids); COMMIT;`;
+  };
+
+  const _extendedRemoveAll = () => {
+    const parentTable = model.getExtendedModel().name;
+    return 'BEGIN;' + `DELETE FROM ${tableName};` +
+      `DELETE FROM ${parentTable};` + 'COMMIT;';
+  };
+
+  const _remove = query => {
     const {conditions} = _buildConditionsAndSorting(query);
-    return `DELETE FROM ${tableName}` + conditions + ' RETURNING *';
+    return `DELETE FROM ${tableName}` + conditions;
   };
 
   const select = (query = {}) => {

--- a/lib/model/definition.js
+++ b/lib/model/definition.js
@@ -39,6 +39,8 @@ const defineModel = (args = {}) => {
     return Object.assign({}, primaryKey);
   };
 
+  const getPrimaryKey = () => primaryKey.primaryKey;
+
   const getKnownFields = (data, schema) => {
     return Object.keys(snakeobj(data)).filter(isKnownField);
   };
@@ -113,7 +115,7 @@ const defineModel = (args = {}) => {
   const schema = {
     collection, getKnownFields, getFieldType, isExtended, isKnownField,
     validatesUniquenessOf, getUniqueIndexes, extend, getExtendedModel,
-    getOwnFields, isOwnField, getCollectionForField, setPrimaryKey
+    getOwnFields, isOwnField, getCollectionForField, setPrimaryKey, getPrimaryKey
   };
 
   const crud = buildCrud(engine, schema);

--- a/test/test-helpers/build-single-table-schema.js
+++ b/test/test-helpers/build-single-table-schema.js
@@ -14,6 +14,7 @@ const definition = {
 
 module.exports = engine => {
   const model = defineModel(Object.assign({}, {collection, definition, engine}));
+  model.setPrimaryKey('id');
   model.validatesUniquenessOf('rating');
   return model;
 };


### PR DESCRIPTION
El extendedModel ya me está cansando. Necesitamos redefinir las cosas porque esto apesta:
```js
    const {foreignKey} = model.getExtendedModel();
    const primaryKey = model.getExtendedModel().model.getPrimaryKey(); <--- Cancer!
    const parentTable = model.getExtendedModel().name;
```
